### PR TITLE
Allow trailing whitespace in blockquote in edit mode

### DIFF
--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -195,14 +195,17 @@ export default class ExpensiMark {
                 // We also want to capture a blank line before or after the quote so that we do not add extra spaces.
                 // block quotes naturally appear on their own line. Blockquotes should not appear in code fences or
                 // inline code blocks. A single prepending space should be stripped if it exists
-                process: (textToProcess, replacement) => {
+                process: (textToProcess, replacement, shouldKeepWhitespace = false) => {
                     const regex = new RegExp(
-                        /\n?^&gt; *(?! )(?![^<]*(?:<\/pre>|<\/code>))([^\v\n\r]+)\n?/gm,
+                        /^&gt; *(?! )(?![^<]*(?:<\/pre>|<\/code>))([^\v\n\r]+)/gm,
                     );
+                    if (shouldKeepWhitespace) {
+                        return textToProcess.replace(regex, replacement);
+                    }
                     return this.modifyTextForQuote(regex, textToProcess, replacement);
                 },
                 replacement: (g1) => {
-                    const replacedText = this.replace(g1, {filterRules: ['heading1'], shouldEscapeText: false});
+                    const replacedText = this.replace(g1.replace(/^&gt;( )?/gm, ''), {filterRules: ['heading1'], shouldEscapeText: false});
                     return `<blockquote>${replacedText}</blockquote>`;
                 },
             },
@@ -407,7 +410,7 @@ export default class ExpensiMark {
      *
      * @returns {String}
      */
-    replace(text, {filterRules = [], shouldEscapeText = true} = {}) {
+    replace(text, {filterRules = [], shouldEscapeText = true, shouldKeepWhitespace = false} = {}) {
         // This ensures that any html the user puts into the comment field shows as raw html
         let replacedText = shouldEscapeText ? _.escape(text) : text;
 
@@ -421,7 +424,7 @@ export default class ExpensiMark {
                 }
 
                 if (rule.process) {
-                    replacedText = rule.process(replacedText, rule.replacement);
+                    replacedText = rule.process(replacedText, rule.replacement, shouldKeepWhitespace);
                 } else {
                     replacedText = replacedText.replace(rule.regex, rule.replacement);
                 }


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

This PR:
- adds new `shouldKeepWhitespace` flag to the `parser.replace` function in ExpensiMark, which allows trailing whitespace in blockquotes
- changes `quote` rule logic when `shouldKeepWhitespace` is true

https://github.com/software-mansion-labs/expensify-common/assets/39538890/3948dcdc-01f2-493e-b14a-851db713bc97

### Fixed Issues
$ GH_LINK

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
1. What tests did you perform that validates your changed worked?

# QA
1. What does QA need to do to validate your changes?
1. What areas to they need to test for regressions?
